### PR TITLE
Fix Cloudflare pnpm install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,7 @@
-allowBuilds:
-  esbuild: true
-  sharp: true
-  workerd: true
+packages:
+  - .
+
+onlyBuiltDependencies:
+  - esbuild
+  - sharp
+  - workerd

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,8 @@ onlyBuiltDependencies:
   - esbuild
   - sharp
   - workerd
+
+allowBuilds:
+  esbuild: true
+  sharp: true
+  workerd: true


### PR DESCRIPTION
## Summary
- Add an explicit root package entry to pnpm-workspace.yaml for Cloudflare's pnpm workspace parsing.
- Keep pnpm 10.x-compatible onlyBuiltDependencies for Cloudflare's pnpm@10.11.1 deploy install.
- Add allowBuilds for newer pnpm installs used by GitHub Actions.

## Why
Cloudflare Workers Builds detected pnpm@10.11.1 and failed during dependency installation with `packages field missing or empty` because the workspace file only contained build approval settings. GitHub Actions then exposed the newer pnpm behavior, where build approvals are read from `allowBuilds`. Keeping both approval forms lets the deploy environment and CI install dependencies without ignoring required build scripts.

## Validation
- `corepack pnpm@10.11.1 install --frozen-lockfile`
- `corepack pnpm@10.11.1 wrangler build`
- `corepack pnpm@11.0.9 install --frozen-lockfile`
- `corepack pnpm@11.0.9 wrangler build`
- `pnpm install --frozen-lockfile`
- `pnpm run typecheck`
- `pnpm run test`
- `git diff --check`